### PR TITLE
Extend autocomplete query to use user's login

### DIFF
--- a/lib/mention/user_patch.rb
+++ b/lib/mention/user_patch.rb
@@ -6,7 +6,7 @@ module Mention
       base.class_eval do
         unloadable
 
-        scope :with_name,->(name) { where('LCASE(CONCAT(firstname," ",lastname)) like ?', "#{name.downcase}%")}
+        scope :with_name,->(name) { where('LCASE(CONCAT(firstname," ",lastname)) like :term OR LCASE(login) like :term', :term => "#{name.downcase}%")}
       end
     end
   end


### PR DESCRIPTION
At the moment only the first- and lastname is used for autocompletion. I think we're not alone at our company to use the user's login as the "primary" name.
